### PR TITLE
Fix correct login/register view in navbar

### DIFF
--- a/src/components/Nav.svelte
+++ b/src/components/Nav.svelte
@@ -12,7 +12,7 @@
             headers: {'Content-Type': 'application/json'},
             credentials: 'include',
         })
-
+        authenticated.set(false);
         await goto('/login');
     }
 </script>


### PR DESCRIPTION
Pressing logout will still view logout button when you are back into login page with no jwt. Setting authentication to false will update the navbar to correct login register button view.


**Incorrect**
![image](https://user-images.githubusercontent.com/68713110/141471094-6c4a314c-8bef-42e8-be5e-0b8916c37b68.png)

**Correct**
![image](https://user-images.githubusercontent.com/68713110/141471243-0b0ce3cb-76db-4fe7-b61d-9675e552270c.png)

